### PR TITLE
fix: 수강신청 버튼 클릭 시 현실적인 대기시간 반영

### DIFF
--- a/Form2.cs
+++ b/Form2.cs
@@ -154,8 +154,11 @@ namespace kw_enrolment_practice
                 return;
             }
 
+            Thread.Sleep(new Random().Next(1000, 1500));
+
             getList.Rows.Add((++getNum).ToString(), codeRef.Text, typeRef.Text, subRef.Text, pointRef.Text, profRef.Text, dayRef.Text, timeRef.Text+"교시", roomRef.Text, "", "", "");
             getList.CurrentCell = null;
+
             clearRef();
             isDone[selected] = true;
             this.Text = "수강신청 성공 과목 수 [" + getNum.ToString() + "/" + numOfSub.ToString() + "]";


### PR DESCRIPTION

실제로 수강신청을 진행할때 조회하는 것에도 일정 대기시간이 걸리지만, 수강신청 버튼을 눌러 등록을 할때도 일정 대기시간이 있습니다.

이를 반영해서 직접적으로 약 1~1.5 초 정도 대기한 뒤에 수강신청이 완료되도록 수정했습니다.
